### PR TITLE
[ARD-014] Increase speed and accuracy of front calibration

### DIFF
--- a/Arduino/README.md
+++ b/Arduino/README.md
@@ -4,12 +4,3 @@ The following libraries have been used:
 3. [ArduinoSort](https://github.com/emilv/ArduinoSort)
 4. [PID_v1](https://github.com/br3ttb/Arduino-PID-Library)
 5. [EnableInterrupt](https://github.com/GreyGnome/EnableInterrupt)
-
-## Pin configurations
-
-sr1 = RBPIN (Right Back)
-sr2 = LPIN (Left)
-sr3 = RFPIN (Right Front)
-sr4 = FPIN (Front)
-sr5 = FLPIN (Front Left)
-sr6 = FRPIN (Front Right)

--- a/Arduino/main/MotorController.ino
+++ b/Arduino/main/MotorController.ino
@@ -1,0 +1,209 @@
+// Rotate left by given degrees. Using 360 degree as a base line
+void rotateLeft(double degree)
+{
+    double target_tick = 4.3589 * degree;
+    //double target_tick = 384;
+    double tick_travelled = 0;
+
+    if (target_tick < 0)
+        return;
+
+    // Init values
+    ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
+    currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
+    oldticksL = oldticksR = 0;
+    speedL = rpmTospeedL(-66.25);
+    speedR = rpmTospeedR(64.9);
+
+    md.setSpeeds(speedL, speedR);
+    tick_travelled = (double)ticksR;
+
+    PIDControlLeft.SetSampleTime(15);  //Controller is called every 50ms
+    PIDControlLeft.SetMode(AUTOMATIC); //Controller is invoked automatically.
+
+    while (tick_travelled < target_tick)
+    {
+        // if not reach destination ticks yet
+        currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
+        currentTicksR = ticksR - oldticksR;
+
+        PIDControlLeft.Compute();
+        oldticksR += currentTicksR; //update ticks
+        oldticksL += currentTicksL;
+        tick_travelled += currentTicksR;
+    }
+
+    md.setBrakes(400, 400);
+    PIDControlLeft.SetMode(MANUAL); //turn off PID
+    delay(delayExplore);
+}
+
+// Rotate right by given degrees. Using 360 degree as a base line
+void rotateRight(double degree)
+{
+    double target_tick = 4.3589 * degree;
+    //double target_tick = 373;
+    double tick_travelled = 0;
+
+    if (target_tick < 0)
+        return;
+
+    // Init values
+    ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
+    currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
+    oldticksL = oldticksR = 0;
+    speedL = rpmTospeedL(66.25);
+    speedR = rpmTospeedR(-64.9);
+
+    md.setSpeeds(speedL, speedR);
+    tick_travelled = (double)ticksR;
+
+    PIDControlRight.SetSampleTime(15);  //Controller is called every 25ms
+    PIDControlRight.SetMode(AUTOMATIC); //Controller is invoked automatically.
+
+    while (tick_travelled < target_tick)
+    {
+        // if not reach destination ticks yet
+        currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
+        currentTicksR = ticksR - oldticksR;
+
+        PIDControlRight.Compute();
+        oldticksR += currentTicksR; //update ticks
+        oldticksL += currentTicksL;
+        tick_travelled += currentTicksR;
+    }
+
+    md.setBrakes(400, 400);
+    PIDControlRight.SetMode(MANUAL);
+
+    delay(delayExplore);
+}
+
+// Move robot forward by distance (in cm)
+void moveForward(float distance)
+{
+    //at 6.10v to 6.20v
+    double target_tick = 0;
+
+    //target_tick = FORWARD_TARGET_TICKS; //289 // EDITED
+    target_tick = 26.85 * distance + FORWARD_TARGET_TICKS;
+    double tick_travelled = 0;
+
+    if (target_tick < 0)
+        return;
+
+    // Init values
+    ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
+    currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
+    oldticksL = oldticksR = 0;
+
+    speedL = rpmTospeedL(LEFT_RPM);  //70.75 //74.9  100
+    speedR = rpmTospeedR(RIGHT_RPM); //70.5 //74.5 99.5
+
+    //Set Final ideal speed and accomodate for the ticks we used in acceleration
+    md.setSpeeds(speedL, speedR);
+    tick_travelled = (double)ticksR;
+
+    PIDControlStraight.SetSampleTime(6.5); //Controller is called every 25ms
+    PIDControlStraight.SetMode(AUTOMATIC); //Controller is invoked automatically using default value for PID
+
+    while (tick_travelled < target_tick)
+    {
+        // if not reach destination ticks yet
+        currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
+        currentTicksR = ticksR - oldticksR;
+
+        PIDControlStraight.Compute();
+
+        oldticksR += currentTicksR; //update ticks
+        oldticksL += currentTicksL;
+        tick_travelled += currentTicksR;
+    }
+
+    //md.setBrakes(370,400);
+    md.setBrakes(350, 350);
+    PIDControlStraight.SetMode(MANUAL);
+    delay(delayExplore);
+}
+
+// Move robot backward by distance (in cm)
+void moveBackward(float distance)
+{
+    //at 6.10v to 6.20v
+    double target_tick = 0;
+    double rpmL, rpmR;
+
+    //target_tick = FORWARD_TARGET_TICKS; //289 // EDITED
+    target_tick = 26.85 * distance + FORWARD_TARGET_TICKS;
+    double tick_travelled = 0;
+
+    if (target_tick < 0)
+        return;
+
+    // Init values
+    ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
+    currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
+    oldticksL = oldticksR = 0;
+
+    //Speed in rpm for motor 1 and 2
+    rpmL = -64.9;
+    rpmR = -64.9;
+
+    speedL = rpmTospeedL(rpmL); //70.75 //74.9  100
+    speedR = rpmTospeedR(rpmR); //70.5 //74.5 99.5
+
+    //Set Final ideal speed and accomodate for the ticks we used in acceleration
+    md.setSpeeds(speedL, speedR);
+    tick_travelled = (double)ticksR;
+
+    PIDControlStraight.SetSampleTime(6.5); //Controller is called every 25ms
+    PIDControlStraight.SetMode(AUTOMATIC); //Controller is invoked automatically using default value for PID
+
+    while (tick_travelled < target_tick)
+    {
+        // if not reach destination ticks yet
+        currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
+        currentTicksR = ticksR - oldticksR;
+
+        PIDControlStraight.Compute();
+
+        oldticksR += currentTicksR; //update ticks
+        oldticksL += currentTicksL;
+        tick_travelled += currentTicksR;
+    }
+
+    //md.setBrakes(370,400);
+    md.setBrakes(250, 250);
+    PIDControlStraight.SetMode(MANUAL);
+    delay(delayExplore);
+}
+
+// Increase ticks (left motor)
+void E1Pos()
+{
+    ticksL++;
+}
+
+// Increase ticks (right motor)
+void E2Pos()
+{
+    ticksR++;
+}
+
+// RPM to speed conversion (left motor)
+double rpmTospeedL(double RPM)
+{
+    if (RPM == 0)
+        return 0;
+    else
+        return 3.6980 * RPM;
+}
+
+// RPM to speed conversion (right motor)
+double rpmTospeedR(double RPM)
+{
+    if (RPM == 0)
+        return 0;
+    else
+        return 4.0999 * RPM;
+}

--- a/Arduino/main/PositionCalibrationController.ino
+++ b/Arduino/main/PositionCalibrationController.ino
@@ -63,40 +63,38 @@ void calibrateFrontAngleLR(bool calibrateDistance) // ID = 2
         float FRdistance = sensorFR.distance();
         float error = FRdistance - FLdistance;
 
-        if (error > 1.40) // Rotate Left
+        if (error > -0.45) // Rotate Left
         {
-            md.setSpeeds(-150, 150);
-            if (error > 2.35)
+            if (error > 0.04)
             {
-                delay(30 * abs(error));
+                rotateLeft(abs(error) / 150);
             }
             else
             {
-                delay(12);
+              rotateLeft(abs(error) / 500);
             }
         }
-        else if (error < 1.30) // Rotate Right
+        else if (error < -0.55) // Rotate Right
         {
-            md.setSpeeds(150, -150);
-            if (error < -0.12)
+            if (error < -1.20)
             {
-                delay(30 * abs(error));
+                rotateRight(abs(error) / 100);
             }
             else
             {
-                delay(12);
+              rotateRight(abs(error) / 500);
             }
         }
         else
         {
-            md.setBrakes(400, 400);
+          error = FRdistance - FLdistance;
+          if(error <= -0.45 && error >= -0.55){
             break;
+          }
         }
 
-        md.setBrakes(100, 100);
-
         count++;
-        if (count > 10)
+        if (count > 100)
         {
             break;
         }
@@ -165,16 +163,30 @@ void calibrateFrontAngleMR(bool calibrateDistance) // ID = 3
 
 void calibrateDistanceL(int id, bool calibrateAngle)
 {
+    float targetDistance = 13.525;
+    int count = 0;
     while (1)
     {
         float LFdistance = sensorFL.distance();
+        float error = abs(targetDistance - LFdistance);
 
-        if (LFdistance > 13.6)
-            moveForward(0.01);
-        else if (LFdistance < 13.4)
-            moveBackward(0.01);
+        if (LFdistance > 13.55)
+            moveForward(error/100);
+        else if (LFdistance < 13.50)
+            moveBackward(error/100);
         else
-            break;
+        {
+            LFdistance = sensorFL.distance();
+            if(LFdistance <= 13.55 && LFdistance >= 13.50){
+              break;
+            }
+        }
+
+        count++;
+
+        if(count > 100) {
+          break;
+        }
     }
 
     float angleError = 0;
@@ -198,16 +210,30 @@ void calibrateDistanceL(int id, bool calibrateAngle)
 
 void calibrateDistanceM(int id, bool calibrateAngle)
 {
+    int count = 0;
+    float targetDistance = 10.81;
     while (1)
     {
         float Fdistance = sensorF.distance();
+        float error = abs(targetDistance - Fdistance);
 
-        if (Fdistance > 10.5)
-            moveForward(0.01);
-        else if (Fdistance < 10.3)
-            moveBackward(0.01);
+        if (Fdistance > 10.82)
+            moveForward(error/100);
+        else if (Fdistance < 10.79)
+            moveBackward(error/100);
         else
-            break;
+        {
+            Fdistance = sensorF.distance();
+            if(Fdistance <= 10.82 && Fdistance >= 10.79){
+              break;
+            }
+        }
+
+        count++;
+
+        if(count > 100) {
+          break;
+        }
     }
 
     float angleError = 0;
@@ -231,16 +257,30 @@ void calibrateDistanceM(int id, bool calibrateAngle)
 
 void calibrateDistanceR(int id, bool calibrateAngle)
 {
+  int count = 0;
+  float targetDistance = 12.475;
     while (1)
     {
         float RFdistance = sensorFR.distance();
+        float error = abs(targetDistance - RFdistance);
 
-        if (RFdistance > 12.9)
-            moveForward(0.01);
-        else if (RFdistance < 12.7)
-            moveBackward(0.01);
+        if (RFdistance > 12.50)
+            moveForward(error/100);
+        else if (RFdistance < 12.45)
+            moveBackward(error/100);
         else
-            break;
+        {
+            RFdistance = sensorFR.distance();
+            if(RFdistance <= 13.55 && RFdistance >= 13.50){
+              break;
+            }
+        }
+
+        count++;
+
+        if(count > 100) {
+          break;
+        }
     }
 
     float angleError = 0;

--- a/Arduino/main/README.md
+++ b/Arduino/main/README.md
@@ -1,3 +1,0 @@
-The following libraries have been used:
-1. [DualVNH5019MotorShield](https://github.com/pololu/dual-vnh5019-motor-shield)
-2. [PinChangeInt](https://github.com/GreyGnome/PinChangeInt)

--- a/Arduino/main/main.ino
+++ b/Arduino/main/main.ino
@@ -12,11 +12,11 @@
 
 //Move Forward fixed distance
 #define FORWARD_DISTANCE 10
-#define MULTIPLE_FORWARD_FACTOR 4.1/3
+#define MULTIPLE_FORWARD_FACTOR 4.1 / 3
 
 //Move Forward Staight
 #define LEFT_RPM 68.5
-#define RIGHT_RPM 65
+#define RIGHT_RPM 67
 
 // For communication
 char source = 't';
@@ -61,7 +61,7 @@ PID PIDControlRight(&a, &a, &a, a, a, a, DIRECT);
 void setup()
 {
   sensorInit();
-  
+
   // Initialise the motor
   md.init();
 
@@ -80,6 +80,7 @@ void setup()
 
 void loop()
 {
+  //printSensors(false);
   runCommands();
 }
 
@@ -191,46 +192,46 @@ void runCommands()
   }
   case '2':
   {
-    moveForward(FORWARD_DISTANCE*2 + MULTIPLE_FORWARD_FACTOR);
+    moveForward(FORWARD_DISTANCE * 2 + MULTIPLE_FORWARD_FACTOR);
     sendAck();
     break;
   }
   case '3':
   {
-    moveForward(FORWARD_DISTANCE*3 + MULTIPLE_FORWARD_FACTOR*2);
+    moveForward(FORWARD_DISTANCE * 3 + MULTIPLE_FORWARD_FACTOR * 2);
     sendAck();
     break;
   }
   case '4':
   {
-    moveForward(FORWARD_DISTANCE*4 + MULTIPLE_FORWARD_FACTOR*3);
+    moveForward(FORWARD_DISTANCE * 4 + MULTIPLE_FORWARD_FACTOR * 3);
     sendAck();
     break;
   }
   case '5':
   {
-    moveForward(FORWARD_DISTANCE*5 + MULTIPLE_FORWARD_FACTOR*4);
+    moveForward(FORWARD_DISTANCE * 5 + MULTIPLE_FORWARD_FACTOR * 4);
     sendAck();
     break;
   }
   case '6':
   {
-    moveForward(FORWARD_DISTANCE*6 + MULTIPLE_FORWARD_FACTOR*5);
+    moveForward(FORWARD_DISTANCE * 6 + MULTIPLE_FORWARD_FACTOR * 5);
     sendAck();
     break;
   }
   case '7':
   {
-    moveForward(FORWARD_DISTANCE*7 + MULTIPLE_FORWARD_FACTOR*6);
+    moveForward(FORWARD_DISTANCE * 7 + MULTIPLE_FORWARD_FACTOR * 6);
     sendAck();
     break;
   }
   case '8':
   {
-    moveForward(FORWARD_DISTANCE*8 + MULTIPLE_FORWARD_FACTOR*7);
+    moveForward(FORWARD_DISTANCE * 8 + MULTIPLE_FORWARD_FACTOR * 7);
     sendAck();
     break;
-  }  
+  }
 
   default:
   {
@@ -241,9 +242,6 @@ void runCommands()
   memset(command_buffer, 0, sizeof(command_buffer));
 }
 
-// ===========================================================================
-// =========================COMMUNICATION SECTION=============================
-// ===========================================================================
 // Send an acknowledgement after every command is executed
 void sendAck()
 {
@@ -252,217 +250,4 @@ void sendAck()
   Serial.print(source);
   Serial.println("Y!");
   Serial.flush();
-}
-
-// ===========================================================================
-// ============================MOVEMENT SECTION===============================
-// ===========================================================================
-// Rotate left by given degrees. Using 360 degree as a base line
-void rotateLeft(double degree)
-{
-  double target_tick = 4.3589 * degree;
-  //double target_tick = 384;
-  double tick_travelled = 0;
-
-  if (target_tick < 0)
-    return;
-
-  // Init values
-  ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
-  currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
-  oldticksL = oldticksR = 0;
-  speedL = rpmTospeedL(-66.25);
-  speedR = rpmTospeedR(64.9);
-
-  md.setSpeeds(speedL, speedR);
-  tick_travelled = (double)ticksR;
-
-  PIDControlLeft.SetSampleTime(15); //Controller is called every 50ms
-  PIDControlLeft.SetMode(AUTOMATIC); //Controller is invoked automatically.
-
-  while (tick_travelled < target_tick)
-  {
-    // if not reach destination ticks yet
-    currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
-    currentTicksR = ticksR - oldticksR;
-
-    PIDControlLeft.Compute();
-    oldticksR += currentTicksR; //update ticks
-    oldticksL += currentTicksL;
-    tick_travelled += currentTicksR;
-  }
-
-  md.setBrakes(400, 400);
-  PIDControlLeft.SetMode(MANUAL); //turn off PID
-  delay(delayExplore);
-}
-
-// Rotate right by given degrees. Using 360 degree as a base line
-void rotateRight(double degree)
-{
-  double target_tick = 4.3589 * degree;
-  //double target_tick = 373;
-  double tick_travelled = 0;
-  
-  if (target_tick < 0)
-    return;
-
-  // Init values
-  ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
-  currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
-  oldticksL = oldticksR = 0;
-  speedL = rpmTospeedL(66.25);
-  speedR = rpmTospeedR(-64.9);
-
-  md.setSpeeds(speedL, speedR);
-  tick_travelled = (double)ticksR;
-
-  PIDControlRight.SetSampleTime(15); //Controller is called every 25ms
-  PIDControlRight.SetMode(AUTOMATIC); //Controller is invoked automatically.
-
-  while (tick_travelled < target_tick)
-  {
-    // if not reach destination ticks yet
-    currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
-    currentTicksR = ticksR - oldticksR;
-
-    PIDControlRight.Compute();
-    oldticksR += currentTicksR; //update ticks
-    oldticksL += currentTicksL;
-    tick_travelled += currentTicksR;
-  }
-
-  md.setBrakes(400, 400);
-  PIDControlRight.SetMode(MANUAL);
-
-  delay(delayExplore);
-}
-
-// Move robot forward by distance (in cm)
-void moveForward(float distance)
-{
-  //at 6.10v to 6.20v
-  double target_tick = 0;
-
-  //target_tick = FORWARD_TARGET_TICKS; //289 // EDITED
-  target_tick = 26.85 * distance + FORWARD_TARGET_TICKS;
-  double tick_travelled = 0;
-
-  if (target_tick < 0)
-    return;
-
-  // Init values
-  ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
-  currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
-  oldticksL = oldticksR = 0;
-
-  speedL = rpmTospeedL(LEFT_RPM); //70.75 //74.9  100
-  speedR = rpmTospeedR(RIGHT_RPM); //70.5 //74.5 99.5
-
-  //Set Final ideal speed and accomodate for the ticks we used in acceleration
-  md.setSpeeds(speedL, speedR);
-  tick_travelled = (double)ticksR;
-  
-  PIDControlStraight.SetSampleTime(6.5); //Controller is called every 25ms
-  PIDControlStraight.SetMode(AUTOMATIC); //Controller is invoked automatically using default value for PID
-
-  while (tick_travelled < target_tick)
-  {
-    // if not reach destination ticks yet
-    currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
-    currentTicksR = ticksR - oldticksR;
-
-    PIDControlStraight.Compute();
-
-    oldticksR += currentTicksR; //update ticks
-    oldticksL += currentTicksL;
-    tick_travelled += currentTicksR;
-  }
-
-  //md.setBrakes(370,400);
-  md.setBrakes(350, 350);
-  PIDControlStraight.SetMode(MANUAL);
-  delay(delayExplore);
-}
-
-// Move robot backward by distance (in cm)
-void moveBackward(float distance)
-{
-  //at 6.10v to 6.20v
-  double target_tick = 0;
-  double rpmL, rpmR;
-
-  //target_tick = FORWARD_TARGET_TICKS; //289 // EDITED
-  target_tick = 26.85 * distance + FORWARD_TARGET_TICKS;
-  double tick_travelled = 0;
-
-  if (target_tick < 0)
-    return;
-
-  // Init values
-  ticksL = ticksR = 0;               //encoder's ticks (constantly increased when the program is running due to interrupt)
-  currentTicksL = currentTicksR = 0; //ticks that we are used to calculate PID. Ticks at the current sampling of PIDController
-  oldticksL = oldticksR = 0;
-
-  //Speed in rpm for motor 1 and 2
-  rpmL = -64.9;
-  rpmR = -64.9;
-  
-  speedL = rpmTospeedL(rpmL); //70.75 //74.9  100
-  speedR = rpmTospeedR(rpmR); //70.5 //74.5 99.5
-
-  //Set Final ideal speed and accomodate for the ticks we used in acceleration
-  md.setSpeeds(speedL, speedR);
-  tick_travelled = (double)ticksR;
-  
-  PIDControlStraight.SetSampleTime(6.5); //Controller is called every 25ms
-  PIDControlStraight.SetMode(AUTOMATIC); //Controller is invoked automatically using default value for PID
-
-  while (tick_travelled < target_tick)
-  {
-    // if not reach destination ticks yet
-    currentTicksL = ticksL - oldticksL; //calculate the ticks travelled in this sample interval of 50ms
-    currentTicksR = ticksR - oldticksR;
-
-    PIDControlStraight.Compute();
-
-    oldticksR += currentTicksR; //update ticks
-    oldticksL += currentTicksL;
-    tick_travelled += currentTicksR;
-  }
-
-  //md.setBrakes(370,400);
-  md.setBrakes(250, 250);
-  PIDControlStraight.SetMode(MANUAL);
-  delay(delayExplore);
-}
-
-// Increase ticks (left motor)
-void E1Pos()
-{
-  ticksL++;
-}
-
-// Increase ticks (right motor)
-void E2Pos()
-{
-  ticksR++;
-}
-
-// RPM to speed conversion (left motor)
-double rpmTospeedL(double RPM)
-{
-  if (RPM == 0)
-    return 0;
-  else
-    return 3.6980 * RPM;
-}
-
-// RPM to speed conversion (right motor)
-double rpmTospeedR(double RPM)
-{
-  if (RPM == 0)
-    return 0;
-  else
-    return 4.0999 * RPM;
 }


### PR DESCRIPTION
#### Improvements:
1. Created 6 functions for each case of calibration of rotation/distance
2. Added counter so that time limit of RPi is not exceeded
3. Rotation/Distance now depends on error magnitude
4. Rotation is decreased by a larger magnitude if robot is closer to enter
5. Error is checked one last time before stopping calibration. This is to avoid error due to the sensor value being wrong.

#### Future improvements:    
1. Add more boundary value conditions for speed
2. Only start counter once error is below a threshold, and thus decrease total count limit.